### PR TITLE
Fix version file URL property

### DIFF
--- a/BatteryActivator.version
+++ b/BatteryActivator.version
@@ -1,6 +1,6 @@
 {
   "NAME": "BatteryActivator",
-  "URL": "https://raw.githubusercontent.com/linuxgurugamer/BatteryActivator/master/BatteryActivator.version",
+  "URL": "https://github.com/linuxgurugamer/BatteryActivator/raw/main/BatteryActivator.version",
   "DOWNLOAD": "https://github.com/linuxgurugamer/BatteryActivator/releases",
   "VERSION": {
     "MAJOR": 1,


### PR DESCRIPTION
The current URL has the wrong branch, main vs master. Now it's fixed.

Tagging @linuxgurugamer because GitHub doesn't like notifying people about pull requests otherwise.

Reminder that @DasSkelett created an awesome tool for validating these files:

- https://github.com/DasSkelett/AVC-VersionFileValidator